### PR TITLE
Add topology spread constraints to Kubernetes deployments

### DIFF
--- a/failing.yaml
+++ b/failing.yaml
@@ -14,6 +14,19 @@ spec:
       labels:
         app: nginx
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: nginx
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: nginx
       containers:
       - name: nginx
         image: alpine:3.13.0

--- a/hello-kubernetes.yaml
+++ b/hello-kubernetes.yaml
@@ -12,6 +12,19 @@ spec:
       labels:
         app: hello-kubernetes
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: hello-kubernetes
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: hello-kubernetes
       containers:
       - name: hello-kubernetes
         image: paulbouwer/hello-kubernetes:1.7

--- a/passing.yaml
+++ b/passing.yaml
@@ -14,6 +14,19 @@ spec:
       labels:
         app: nginx
     spec:
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: "topology.kubernetes.io/zone"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: nginx
+        - maxSkew: 1
+          topologyKey: "kubernetes.io/hostname"
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: nginx
       containers:
       - name: nginx
         image: nginx:1.18-alpine


### PR DESCRIPTION
## 🔧 Fairwinds Insights Automated Remediation

This PR addresses **Fairwinds Insights Action Item #95**: "Pod should be configured with a valid topology spread constraint"

### Changes Made

Added topology spread constraints to all Kubernetes deployment manifests:

- ✅ **`passing.yaml`** - nginx-deployment (3 replicas) 
- ✅ **`failing.yaml`** - nginx-deployment-2 (1 replica)
- ✅ **`hello-kubernetes.yaml`** - hello-kubernetes (1 replica)

### Implementation Details

Each deployment now includes topology spread constraints that:

- **Spread pods across availability zones** using `topology.kubernetes.io/zone`
- **Spread pods across different nodes** using `kubernetes.io/hostname`
- **Use flexible scheduling** with `ScheduleAnyway` policy to avoid blocking deployment
- **Match proper labels** for each deployment's pod selector

### Configuration Added

```yaml
topologySpreadConstraints:
  - maxSkew: 1
    topologyKey: "topology.kubernetes.io/zone"
    whenUnsatisfiable: ScheduleAnyway
    labelSelector:
      matchLabels:
        app: <app-name>
  - maxSkew: 1
    topologyKey: "kubernetes.io/hostname" 
    whenUnsatisfiable: ScheduleAnyway
    labelSelector:
      matchLabels:
        app: <app-name>
```

### Benefits

- **High Availability**: Pods will be distributed across failure domains
- **Fault Tolerance**: Reduces impact of zone or node failures
- **Best Practices**: Follows Kubernetes recommendations for multi-replica deployments
- **Non-disruptive**: `ScheduleAnyway` ensures existing workloads continue to function

### Validation

- ✅ YAML syntax validated
- ✅ Label selectors correctly match deployment specs
- ✅ Configuration follows Kubernetes documentation standards

---

_This PR was created by an AI agent (OpenHands) for automated Fairwinds Insights remediation._

@jdesouza can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ab77992c-a501-4c94-a14d-12f8d3280bc9)