### PR TITLE
Fix privilege escalation security issue [104] - Privilege escalation should not be allowed

### DIFF
--- a/failing.yaml
+++ b/failing.yaml
@@ -20,7 +20,7 @@ spec:
         ports:
         - containerPort: 80
         securityContext:
-          allowPrivilegeEscalation: true
+          allowPrivilegeEscalation: false
           privileged: true
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/hello-kubernetes.yaml
+++ b/hello-kubernetes.yaml
@@ -24,3 +24,5 @@ spec:
           limits:
             memory: "8Gi"
             cpu: "500m"
+        securityContext:
+          allowPrivilegeEscalation: false


### PR DESCRIPTION
## Description

This PR addresses Fairwinds Insights action item **#104: Privilege escalation should not be allowed**.

## Changes Made

✅ **failing.yaml**: Changed `allowPrivilegeEscalation` from `true` to `false`
✅ **hello-kubernetes.yaml**: Added `securityContext` with `allowPrivilegeEscalation: false`

## Security Context

Under particular configurations, containers could escalate their privileges. Setting `allowPrivilegeEscalation` to `false` sets the [`no_new_privs` flag](https://www.kernel.org/doc/html/latest/userspace-api/no_new_privs.html) on container processes, preventing `setuid` binaries from changing the effective user ID.

This change is particularly important when using `runAsNonRoot`, which can otherwise be circumvented.

## Risk Assessment

**Risk**: Low
- **What could go wrong**: Applications relying on privilege escalation (setuid binaries, sudo) may fail to function correctly
- **Blast radius**: Affects containers in failing.yaml and hello-kubernetes.yaml deployments
- **Severity**: Low - breaking change only if applications explicitly need privilege escalation
- **Rollback**: Revert this commit to restore previous behavior if applications break
- **Mitigation**: Test deployments after applying changes; temporarily revert if critical functionality is impacted

## References

- [Kubernetes Security Context Documentation](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
- [Linux no_new_privs flag](https://www.kernel.org/doc/html/latest/userspace-api/no_new_privs.html)

---
Resolves Fairwinds Insights action item #104

@jdesouza can click here to [continue refining the PR](https://app.all-hands.dev/conversations/8ca1910e-4cca-4e52-9f9d-68f8bb619b73)