### PR TITLE
Fix privilege escalation security issue (#106)

### DIFF
--- a/failing.yaml
+++ b/failing.yaml
@@ -20,7 +20,7 @@ spec:
         ports:
         - containerPort: 80
         securityContext:
-          allowPrivilegeEscalation: true
+          allowPrivilegeEscalation: false
           privileged: true
           readOnlyRootFilesystem: true
           runAsNonRoot: false

--- a/hello-kubernetes.yaml
+++ b/hello-kubernetes.yaml
@@ -24,3 +24,5 @@ spec:
           limits:
             memory: "8Gi"
             cpu: "500m"
+        securityContext:
+          allowPrivilegeEscalation: false


### PR DESCRIPTION
## Security Fix: Disable Privilege Escalation in Containers

This PR addresses **Fairwinds Insights action item #106: Privilege escalation should not be allowed**.

### Changes Made

- **failing.yaml**: Changed `allowPrivilegeEscalation: true` to `allowPrivilegeEscalation: false`
- **hello-kubernetes.yaml**: Added `securityContext` with `allowPrivilegeEscalation: false`

### Security Impact

Setting `allowPrivilegeEscalation: false` prevents containers from escalating their privileges by:
- Setting the [`no_new_privs` flag](https://www.kernel.org/doc/html/latest/userspace-api/no_new_privs.html) on the container process
- Preventing `setuid` binaries from changing the effective user ID
- Providing additional protection when using `runAsNonRoot` security contexts

### Risk Assessment

**Risk Level**: Low  
**Blast Radius**: Containers in these deployments only  
**Severity**: Low  
**Rollback**: Simple revert of this PR if applications fail due to privilege requirements

### Testing Notes

Please verify that the applications in these deployments continue to function correctly after deployment. If any container requires privilege escalation for legitimate purposes, those requirements should be explicitly documented and reviewed.

Fixes Fairwinds Insights action item #106

@jdesouza can click here to [continue refining the PR](https://app.all-hands.dev/conversations/ce411054-0aab-42d6-8788-ca4d325aeaaa)