### PR TITLE
Fix privilege escalation in nginx-deployment-2

### DIFF
--- a/failing.yaml
+++ b/failing.yaml
@@ -20,7 +20,7 @@ spec:
         ports:
         - containerPort: 80
         securityContext:
-          allowPrivilegeEscalation: true
+          allowPrivilegeEscalation: false
           privileged: true
           readOnlyRootFilesystem: true
           runAsNonRoot: false


### PR DESCRIPTION
This PR addresses the issue `ai-nginx-priv-esc` where the container `nginx` may escalate privileges.

**Details:**
- **Severity:** medium
- **Rule ID:** polaris/privilegeEscalationAllowed
- **Remediation:** Set `securityContext.allowPrivilegeEscalation` to `false`.