### PR TITLE
fix(failing.yaml): set securityContext.privileged=false for nginx-deployment-2

### DIFF
--- a/failing.yaml
+++ b/failing.yaml
@@ -21,7 +21,7 @@ spec:
         - containerPort: 80
         securityContext:
           allowPrivilegeEscalation: true
-          privileged: true
+          privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
           capabilities:


### PR DESCRIPTION
### Remediation for `ai-nginx-run-as-privileged`

- **Severity:** high
- **Rule ID:** polaris/runAsPrivileged
- **Description:** privileged determines if any container in a pod can enable privileged mode. A privileged container can access all devices on the host with nearly the same access as host processes.
- **Remediation:** In your workload configuration, set securityContext.privileged = false. Test after change; privileged mode has high blast radius.