### PR TITLE
fix(failing.yaml): disable privileged mode for nginx-deployment-2

### DIFF
--- a/failing.yaml
+++ b/failing.yaml
@@ -21,7 +21,7 @@ spec:
         - containerPort: 80
         securityContext:
           allowPrivilegeEscalation: true
-          privileged: true
+          privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
           capabilities:


### PR DESCRIPTION
This PR addresses the security concern identified by Polaris rule `polaris/runAsPrivileged` (ID: `ai-nginx-run-as-privileged`, Severity: `high`).

**Remediation:** Set `securityContext.privileged = false` to prevent the container from running in privileged mode, which limits potential host access.