### PR TITLE
fix: disable privileged mode for nginx-deployment-2

### DIFF
--- a/failing.yaml
+++ b/failing.yaml
@@ -21,7 +21,7 @@ spec:
         - containerPort: 80
         securityContext:
           allowPrivilegeEscalation: true
-          privileged: true
+          privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
           capabilities:


### PR DESCRIPTION
### Remediation for Action Item 101
- **Severity**: high (0.75)
- **Rule ID**: polaris/runAsPrivileged
- **Description**: `privileged` determines if any container in a pod can enable privileged mode. 

The securityContext for the `nginx` container has been updated to set `privileged: false`.