### PR TITLE
[Fairwinds Insights #106] Fix privileged container security issue

### DIFF
--- a/failing.yaml
+++ b/failing.yaml
@@ -21,7 +21,7 @@ spec:
         - containerPort: 80
         securityContext:
           allowPrivilegeEscalation: true
-          privileged: true
+          privileged: false
           readOnlyRootFilesystem: true
           runAsNonRoot: false
           capabilities:


### PR DESCRIPTION
## Summary
Fixes security vulnerability identified by Fairwinds Insights action item #106: **Should not be running as privileged**

## Changes Made
- Set `securityContext.privileged = false` in the nginx deployment configuration in `failing.yaml`
- Removed unnecessary privileged access that could expose the host system to security risks

## Risk Assessment
**Risk**: Low
- **What could go wrong**: The container may fail to start if it actually requires privileged access for specific functionality
- **Blast radius**: Single nginx deployment (`nginx-deployment-2`) in the failing.yaml configuration
- **Severity**: Low - This appears to be a test/example configuration file based on the filename
- **Rollback**: Simple revert of the single-line change from `privileged: false` back to `privileged: true` if needed

## Security Impact
- **Before**: Container had unrestricted access to host devices and capabilities
- **After**: Container runs with standard, non-privileged security context
- **Benefit**: Significantly reduces attack surface and prevents potential container escape scenarios

## Remediation Details
This addresses the Fairwinds Insights finding:
> `privileged` determines if any container in a pod can enable privileged mode. By default a container is not allowed to access any devices on the host, but a `privileged` container is given access to all devices on the host. This allows the container nearly all the same access as processes running on the host.

The fix follows the recommended remediation: **set `securityContext.privileged = false`**

## Testing
- Configuration change is minimal and follows security best practices
- No functional changes to the application itself
- Container should continue to operate normally without privileged access

@jdesouza can click here to [continue refining the PR](https://app.all-hands.dev/conversations/296eeb40-f9fd-4835-8e7b-96bf5fe49433)