### PR TITLE
Fix Fairwinds Insights #7098: Only one replica is scheduled

### DIFF
--- a/failing.yaml
+++ b/failing.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: nginx
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: nginx


### PR DESCRIPTION
## Summary

This PR addresses Fairwinds Insights action item #7098 - "Only one replica is scheduled" by increasing the replica count in the nginx deployment configuration.

## Changes Made

- Updated `failing.yaml` deployment from 1 to 3 replicas
- Changed line 8: `replicas: 1` → `replicas: 3`

## Why This Fix

**Problem**: The deployment `nginx-deployment-2` was configured with only 1 replica, creating a single point of failure and poor availability characteristics.

**Solution**: Increased to 3 replicas to:
- Eliminate single point of failure
- Provide better load distribution  
- Improve application availability and fault tolerance
- Align with the pattern used in `passing.yaml`

## Risk Assessment

- **What could go wrong**: Minimal risk - this change only increases replica count, improving system resilience
- **Blast radius**: Affects the `nginx-deployment-2` deployment only  
- **Severity**: Low - This is a configuration improvement with no breaking changes
- **Rollback/mitigation**: Can easily revert the replica count if needed, or scale down manually using `kubectl scale deployment nginx-deployment-2 --replicas=1`

## Validation

The change follows the same pattern as the existing `passing.yaml` configuration, which already uses 3 replicas successfully.

_This PR was created by an AI agent (OpenHands) on behalf of the user to resolve Fairwinds Insights remediation._

@jdesouza can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4dc3eb75-d703-4373-b868-8fe3cee3c7ec)