### PR TITLE
Fix Fairwinds Insights issue [7098]: Increase replica count from 1 to 3

### DIFF
--- a/failing.yaml
+++ b/failing.yaml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: nginx
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: nginx

--- a/hello-kubernetes.yaml
+++ b/hello-kubernetes.yaml
@@ -3,7 +3,7 @@ kind: Deployment
 metadata:
   name: hello-kubernetes
 spec:
-  replicas: 1
+  replicas: 3
   selector:
     matchLabels:
       app: hello-kubernetes


### PR DESCRIPTION
## Summary
This PR addresses Fairwinds Insights Action Item **[7098] "Only one replica is scheduled"** by increasing the replica count from 1 to 3 in Kubernetes deployment configurations.

## Changes
- Updated `failing.yaml`: Changed `replicas: 1` to `replicas: 3` 
- Updated `hello-kubernetes.yaml`: Changed `replicas: 1` to `replicas: 3`

## Risk Assessment
### Risk: **Low** 
**What could go wrong:** 
- Slightly increased resource consumption (CPU/memory) due to running 2 additional pods per deployment
- Potential scheduling issues if cluster lacks sufficient resources

**Blast radius:** 
- Affects nginx-deployment-2 and hello-kubernetes deployments only
- Impact limited to these specific applications

**Rollback:** 
- Simple rollback via `kubectl scale deployment <name> --replicas=1` 
- Or revert this PR and redeploy original configurations

**Mitigation:** 
- Monitor cluster resource usage after deployment
- Kubernetes scheduler will automatically handle pod placement across available nodes

## Benefits
- **Eliminates single points of failure** for both deployments
- **Improves availability** during node failures or pod restarts
- **Enables rolling updates** with zero downtime
- **Aligns with production best practices** for reliability

## Fairwinds Insights Remediation
Resolves Action Item: **[7098] Only one replica is scheduled**

This change ensures high availability by running multiple replicas of each deployment, preventing service disruption when individual pods fail or are restarted.

---

_This pull request was created by an AI agent (OpenHands) on behalf of automated remediation._