### PR TITLE
Fix CPU limits for Fairwinds Insights action item 7101

### DIFF
--- a/failing.yaml
+++ b/failing.yaml
@@ -19,6 +19,13 @@ spec:
         image: alpine:3.13.0
         ports:
         - containerPort: 80
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "64Mi"
+          limits:
+            cpu: "200m"
+            memory: "128Mi"
         securityContext:
           allowPrivilegeEscalation: true
           privileged: true

--- a/nginx-flux-file.yaml
+++ b/nginx-flux-file.yaml
@@ -25,4 +25,7 @@ spec:
     resources:
       requests:
         cpu: 100m
-        memory: 64Mi 
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi


### PR DESCRIPTION
## Summary
This pull request addresses Fairwinds Insights action item **[7101] CPU limits should be set** by adding missing CPU and memory resource limits to Kubernetes manifests.

## Changes Made

### 1. `failing.yaml` - Added complete resources section
- **Before**: No resource limits or requests defined
- **After**: Added conservative CPU (100m request, 200m limit) and memory (64Mi request, 128Mi limit)

### 2. `nginx-flux-file.yaml` - Added missing limits
- **Before**: Only had CPU requests (100m) and memory requests (64Mi)
- **After**: Added CPU limits (200m) and memory limits (128Mi) to complement existing requests

## Risk Assessment

**What could go wrong:**
- Setting limits too low could cause container restarts or performance issues
- nginx-ingress controller might need higher limits under load

**Blast radius:** 
- `failing.yaml`: Affects only nginx-deployment-2 workload
- `nginx-flux-file.yaml`: Affects backend nginx-ingress HelmRelease in default namespace

**Severity:** Low-Medium - Conservative limits chosen (2x request values)

**Rollback:** Can easily revert by removing limits sections or adjusting values upward

## Testing
- Limits are set conservatively with 2:1 ratio (limit:request)
- Values align with typical nginx container resource usage patterns
- HelmRelease will apply limits through Flux CD reconciliation

Resolves Fairwinds Insights action item **7101: CPU limits should be set**

@jdesouza can click here to [continue refining the PR](https://app.all-hands.dev/conversations/e19fedb4-93c2-431c-bb21-075f4f535a44)