### PR TITLE
fix: Add CPU limits to address Fairwinds Insights action item 7101

### DIFF
--- a/failing.yaml
+++ b/failing.yaml
@@ -19,6 +19,13 @@ spec:
         image: alpine:3.13.0
         ports:
         - containerPort: 80
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "128Mi"
+          limits:
+            cpu: "500m"
+            memory: "256Mi"
         securityContext:
           allowPrivilegeEscalation: true
           privileged: true

--- a/nginx-flux-file.yaml
+++ b/nginx-flux-file.yaml
@@ -25,4 +25,7 @@ spec:
     resources:
       requests:
         cpu: 100m
-        memory: 64Mi 
+        memory: 64Mi
+      limits:
+        cpu: 200m
+        memory: 128Mi 


### PR DESCRIPTION
## Summary
This PR addresses Fairwinds Insights action item **[7101] CPU limits should be set** by adding resource limits to containers that were missing them.

## Changes Made
- ✅ **failing.yaml**: Added CPU limits (500m) and memory limits (256Mi) with appropriate requests to the nginx container in `nginx-deployment-2`
- ✅ **nginx-flux-file.yaml**: Added CPU limits (200m) and memory limits (128Mi) to complement existing requests in the backend HelmRelease

## Risk Assessment

### Risk: Low to Medium
**What could go wrong:**
- Container resource constraints could cause performance issues if limits are too restrictive
- Pod eviction if memory usage exceeds limits during traffic spikes

**Blast radius:** 
- Limited to the affected deployments (`nginx-deployment-2` and backend HelmRelease)
- Does not affect existing properly configured deployments

**Severity:** Low
- Changes align with Kubernetes best practices
- Limits are set conservatively based on typical nginx workload requirements
- Memory limits include reasonable buffer above requests

**Rollback/Mitigation:**
- Easy rollback via git revert or manual resource limit adjustments
- Kubernetes will automatically restart pods if limits cause issues
- Can increase limits quickly if performance problems arise

## Fairwinds Insights Compliance
- ✅ Resolves action item [7101]: "CPU limits should be set"
- ✅ Follows resource management best practices  
- ✅ Maintains backward compatibility

## Testing
- Configuration validated for proper YAML syntax
- Resource limit values follow Kubernetes conventions
- Changes are minimal and focused on the specific compliance requirement